### PR TITLE
Make subscription functionality push to subscribers instead of having them poll

### DIFF
--- a/src/bin/server/handler.rs
+++ b/src/bin/server/handler.rs
@@ -305,7 +305,7 @@ mod tests {
         let settings: Settings = Default::default();
         let global = Arc::new(RwLock::new(SharedState::new(settings)));
         let store = Arc::new(RwLock::new(HashMap::new()));
-        let (tx, _) = futures::sync::mpsc::channel::<Update>(1);
+        let (tx, _) = futures::sync::mpsc::unbounded::<Update>();
         ThreadState::new(global, store, tx)
     }
 

--- a/src/bin/server/handler.rs
+++ b/src/bin/server/handler.rs
@@ -299,12 +299,14 @@ mod tests {
     use settings::Settings;
     use std::sync::{Arc, RwLock};
     use std::collections::HashMap;
+    use futures;
 
     fn gen_state<'thr, 'store>() -> ThreadState<'thr, 'store> {
         let settings: Settings = Default::default();
         let global = Arc::new(RwLock::new(SharedState::new(settings)));
         let store = Arc::new(RwLock::new(HashMap::new()));
-        ThreadState::new(global, store)
+        let (tx, _) = futures::sync::mpsc::channel::<Update>(1);
+        ThreadState::new(global, store, tx)
     }
 
     #[test]

--- a/src/bin/server/server.rs
+++ b/src/bin/server/server.rs
@@ -12,7 +12,7 @@ use std::io::{BufReader, Write};
 use std::net::SocketAddr;
 use std::rc::Rc;
 use std::str;
-use std::sync::{Arc, RwLock, Mutex};
+use std::sync::{Arc, RwLock};
 
 use state::{Global, SharedState, ThreadState};
 use handler::ReturnType;

--- a/src/bin/server/server.rs
+++ b/src/bin/server/server.rs
@@ -64,7 +64,7 @@ pub fn run_server(host: &str, port: &str, settings: &Settings) {
 
         // channel for pushing subscriptions directly from subscriptions thread
         // to client socket
-        let (subscriptions_tx, subscriptions_rx) = mpsc::channel::<Update>(1);
+        let (subscriptions_tx, subscriptions_rx) = mpsc::unbounded::<Update>();
 
         let global_copy = global.clone();
         let state = Rc::new(RefCell::new(

--- a/src/bin/server/state.rs
+++ b/src/bin/server/state.rs
@@ -21,10 +21,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 use handler::{GetFormat, ReturnType, ReqCount, Loc, Range};
 use subscription::Subscriptions;
+use futures;
 
 /// An atomic reference counter for accessing shared data.
 pub type Global = Arc<RwLock<SharedState>>;
 pub type HashMapStore<'a> = Arc<RwLock<HashMap<String, Store<'a>>>>;
+pub type SubscriptionTX = futures::sync::mpsc::Sender<Update>;
 
 /// name: *should* be the filename
 /// in_memory: are the updates read into memory?
@@ -230,6 +232,8 @@ pub struct ThreadState<'thr, 'store> {
     pub sub_id: Option<usize>,
     /// current receiver
     pub rx: Option<Arc<Mutex<mpsc::Receiver<Update>>>>,
+
+    pub subscription_tx: SubscriptionTX,
 
     /// mapping store_name -> Store
     pub store: Arc<RwLock<HashMap<String, Store<'store>>>>,
@@ -625,7 +629,11 @@ impl<'thr, 'store> ThreadState<'thr, 'store> {
     }
 
     /// create a new threadstate
-    pub fn new<'a, 'b>(global: Global, store: HashMapStore<'b>) -> ThreadState<'a, 'b> {
+    pub fn new<'a, 'b>(
+        global: Global,
+        store: HashMapStore<'b>,
+        subscription_tx: SubscriptionTX,
+    ) -> ThreadState<'a, 'b> {
         let dtf_folder: &str = &global.read().unwrap().settings.dtf_folder;
         let state = ThreadState {
             current_store_name: "default".into(),
@@ -634,6 +642,7 @@ impl<'thr, 'store> ThreadState<'thr, 'store> {
             subscribed_db: None,
             sub_id: None,
             rx: None,
+            subscription_tx: subscription_tx,
             store,
             global: global.clone(),
         };

--- a/src/bin/server/state.rs
+++ b/src/bin/server/state.rs
@@ -470,7 +470,8 @@ impl<'thr, 'store> ThreadState<'thr, 'store> {
         self.is_subscribed = true;
         self.subscribed_db = Some(dbname.to_owned());
         let glb = self.global.read().unwrap();
-        let (id, rx) = glb.subs.lock().unwrap().sub(dbname.to_owned());
+        let (id, rx) = glb.subs.lock().unwrap()
+            .sub(dbname.to_owned(), self.subscription_tx.clone());
         self.rx = Some(rx);
         self.sub_id = Some(id);
         info!("Subscribing to channel {}. id: {}", dbname, id);

--- a/src/bin/server/state.rs
+++ b/src/bin/server/state.rs
@@ -643,7 +643,7 @@ impl<'thr, 'store> ThreadState<'thr, 'store> {
             subscribed_db: None,
             sub_id: None,
             rx: None,
-            subscription_tx: subscription_tx,
+            subscription_tx,
             store,
             global: global.clone(),
         };

--- a/src/bin/server/state.rs
+++ b/src/bin/server/state.rs
@@ -26,7 +26,7 @@ use futures;
 /// An atomic reference counter for accessing shared data.
 pub type Global = Arc<RwLock<SharedState>>;
 pub type HashMapStore<'a> = Arc<RwLock<HashMap<String, Store<'a>>>>;
-pub type SubscriptionTX = futures::sync::mpsc::Sender<Update>;
+pub type SubscriptionTX = futures::sync::mpsc::UnboundedSender<Update>;
 
 /// name: *should* be the filename
 /// in_memory: are the updates read into memory?

--- a/src/bin/server/subscription.rs
+++ b/src/bin/server/subscription.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use libtectonic::dtf::update::Update;
 
 use futures;
-use futures::{Sink, Future};
 
 pub type Event = Arc<Mutex<(String, Update)>>;
 

--- a/src/bin/server/subscription.rs
+++ b/src/bin/server/subscription.rs
@@ -200,7 +200,7 @@ impl Subscription {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::{Stream};
+    use futures::{Stream,Future};
     use tokio_core::reactor::Core;
 
     #[test]
@@ -219,7 +219,7 @@ mod tests {
 
         let mut subs = Subscriptions::new();
         let (subscription_tx, subscription_rx) = futures::sync::mpsc::unbounded::<Update>();
-        let (_id, rx) = subs.sub(symbol.clone(), subscription_tx);
+        let (_id, _) = subs.sub(symbol.clone(), subscription_tx);
 
         subs.msg(event);
 


### PR DESCRIPTION
I've modified the subscription functionality to push to the clients when the databases they're subscribed to gets any updates.

I still haven't deleted the handler command that responded to poll requests because I wasn't sure we wanted to support both modes (though currently this version doesn't write to the receiver from which polling reads data from).

If we do want to support both modes, we could do something like what Redis does, i.e. only allow a subset of the commands when subscribed. This would prevent weird scenarios like: receiving some update via push, and then receiving that same update on the next poll.

Please let me know if you think this is the right approach.