### PR TITLE
Stop DTFBufReader iterator from skipping a byte between iterations

### DIFF
--- a/src/lib/dtf/file_format.rs
+++ b/src/lib/dtf/file_format.rs
@@ -517,10 +517,8 @@ impl Iterator for DTFBufReader {
 fn read_n_batches<T: BufRead + Seek>(mut rdr: &mut T, num_rows: u32) -> Result<Vec<Update>, io::Error> {
     let mut v: Vec<Update> = vec![];
     let mut count = 0;
+    if num_rows == 0 { return Ok(v); }
     while let Ok(is_ref) = rdr.read_u8() {
-        if count > num_rows {
-            break;
-        }
 
         if is_ref == 0x1 {
             rdr.seek(SeekFrom::Current(-1)).expect("ROLLBACK ONE BYTE");
@@ -528,6 +526,10 @@ fn read_n_batches<T: BufRead + Seek>(mut rdr: &mut T, num_rows: u32) -> Result<V
         }
 
         count += 1;
+
+        if count > num_rows {
+            break;
+        }
     }
     Ok(v)
 }


### PR DESCRIPTION
Check for stop condition before the next iteration of the loop so we don't read an extra byte from `DTFBufReader` in case we need to call it again and read n more batches.

This fixes an issue with the `dtfsplit` tool which stopped after the first iteration, caused by skipping a byte between successive calls to `read_n_batches`.