### PR TITLE
Improve `dtfconcat` and `dtfsplit` tools

### DIFF
--- a/src/bin/dtfconcat/main.rs
+++ b/src/bin/dtfconcat/main.rs
@@ -130,7 +130,7 @@ fn combine_files(
         .cloned()
         .collect();
 
-    println!("FILE1 UPDATES: {:?}", file1_updates);
+    println!("FILE1 UPDATES: {:?}", file1_updates.len());
 
     // Read updates from the millisecond of overlap between the two files
     // let mut overlap_updates_1: Vec<Update> = dtf::get_range_in_file(
@@ -172,7 +172,7 @@ fn combine_files(
         .collect();
     overlapping_updates.sort();
 
-    println!("OVERLAP UPDATES: {:?}", overlapping_updates);
+    println!("OVERLAP UPDATES: {:?}", overlapping_updates.len());
 
     // Read updates from the second file starting where the first file left off
     // let mut file2_updates: Vec<Update> = dtf::get_range_in_file(
@@ -187,7 +187,7 @@ fn combine_files(
         .collect();
     drop(full_file2);
 
-    println!("FILE2 UPDATES: {:?}", file2_updates);
+    println!("FILE2 UPDATES: {:?}", file2_updates.len());
 
     // Concat the buffers together, deduplicate, and output into a DTF file
     let mut joined_updates = file1_updates;

--- a/src/lib/dtf/file_format.rs
+++ b/src/lib/dtf/file_format.rs
@@ -40,7 +40,7 @@ static SYMBOL_OFFSET: u64 = 5;
 static LEN_OFFSET: u64 = 25;
 static MAX_TS_OFFSET: u64 = 33;
 static MAIN_OFFSET: u64 = 80; // main section start at 80
-// static ITEM_OFFSET : u64 = 13; // each item has 13 bytes
+static ITEM_OFFSET : u64 = 13; // each item has 13 bytes
 
 #[derive(Debug, Eq, PartialEq, PartialOrd)]
 pub struct Metadata {
@@ -502,7 +502,51 @@ impl DTFBufReader {
             batch_size,
         }
     }
+
+    pub fn as_chunks(self, chunk_size: u64) -> ChunkedDTFBufReader {
+        ChunkedDTFBufReader {
+            dtf_buf_reader: self,
+            chunk_size,
+        }
+    }
 }
+
+pub struct ChunkedDTFBufReader {
+    pub dtf_buf_reader: DTFBufReader,
+    chunk_size: u64,
+}
+
+impl Iterator for ChunkedDTFBufReader {
+    type Item = Vec<Update>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let v = read_n_bytes_updates(
+            &mut self.dtf_buf_reader.rdr,
+            self.chunk_size,
+        ).ok()?;
+        if 0 != v.len() { Some(v) }
+        else { None }
+    }
+}
+
+pub fn read_n_bytes_updates<T: BufRead + Seek>(
+    mut rdr: &mut T,
+    chunk_size: u64,
+) -> Result<Vec<Update>, io::Error> {
+    let mut v: Vec<Update> = vec![];
+    // disregarding batch metadata and file headers, we can approximate the file
+    // size v would take by doing: v.len() * size of an update (ITEM_OFFSET)
+    let limit = chunk_size / ITEM_OFFSET;
+    if chunk_size == 0 { return Ok(v); }
+    while let Ok(is_ref) = rdr.read_u8() {
+        if is_ref == 0x1 {
+            rdr.seek(SeekFrom::Current(-1)).expect("ROLLBACK ONE BYTE");
+            v.extend(read_one_batch(&mut rdr)?);
+        }
+        if (v.len() as u64) > limit { break; }
+    }
+    Ok(v)
+}
+
 
 impl Iterator for DTFBufReader {
     type Item = Vec<Update>;


### PR DESCRIPTION
Changes:

1. Add option to `dtfsplit` to split by output size. Currently `dtfsplit` only splits by full batches which can vary widely (I've seen 2-12000 updates per batch), so there's no reliable way of controlling the size of the output files by changing the batch_size parameter.

2. Fix bug in `dtfconcat` where the file with the latest updates is considered the `start_file`.

3. Add a `discontinuity_cutoff` option to `dtfconcat` (defaults to 0 to keep the current functionality). This allows us to merge back files split by `dtfsplit` (which don't have overlaps but can have gaps of a couple of milliseconds)
